### PR TITLE
fix: add weights to expression simplifier

### DIFF
--- a/src/sets/other/simplifier/index.ts
+++ b/src/sets/other/simplifier/index.ts
@@ -7,8 +7,22 @@ import { RESERVED_LABELS } from '../constants'
 
 const MAX_VARIABLES = 8
 const RESERVED = new Set<string>(RESERVED_LABELS)
+const OPERATOR_WEIGHTS = {
+  '\\cup': 1,
+  '\\cap': 1,
+  '^{\\complement}': 1,
+  '\\setminus': 2,
+  '\\triangle': 3,
+} as const
 
 const normalize = (s: string) => s.replace(/\s/g, '')
+
+const countOperatorWeight = (latex: string): number => {
+  const s = normalize(latex)
+  return Object.entries(OPERATOR_WEIGHTS).reduce((total, [op, weight]) => (
+    total + (s.split(op).length - 1) * weight
+  ), 0)
+}
 
 const trySimplify = (
   node: MathJsonExpression,
@@ -64,9 +78,7 @@ export const simplify = (
     current = next
   }
 
-  // had some issues with it generating "simpler" expressions that were actually longer than the original
-  // so this is a temporary fix
-  if (result && normalize(result).length > normalize(latex).length) return null
+  if (result && countOperatorWeight(result) > countOperatorWeight(latex)) return null
 
   return result
 }


### PR DESCRIPTION
addresses comments of #32 in which it defines a weight for each operator and therefore blocks expressions from being too complex with the simplifier.