### PR TITLE
fix: latex input errors do not allow for coloring

### DIFF
--- a/src/sets/composables/useExpressionAnalysis.ts
+++ b/src/sets/composables/useExpressionAnalysis.ts
@@ -57,10 +57,12 @@ export const useExpressionAnalysis = (
 
   const activeSubsets = computed(() => {
     const parse = setParser(allSections.value);
+    const sets = definedSets.value;
     const results: HighlightGroup[] = [];
 
     for (const [index, expression] of expressions.value.entries()) {
       if (expression.hidden) continue;
+      if (hasInputError(expression.value, parse, sets)) continue;
 
       const mathJSON = parseMathJSON(expression.value);
       if (!mathJSON) continue;


### PR DESCRIPTION
previously errors in the latex input would still allow for coloring of the canvas. now the same check that runs on the input runs on the canvas to make sure that only valid latex and valid sets are colored.

fixes #42 